### PR TITLE
Generate code for dicovering initial language at compile time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,5 @@
 # CHANGELOG
 
-## 2024-02-09 - v0.0.3
+## 2024-02-09 - v0.0.X
 
-### New features
-
-Added some parameters to `leptos_fluent!` macro:
-
-- `initial_language_from_url`
-- `initial_language_from_url_param`
-- `initial_language_from_url_to_localstorage`
-- `initial_language_from_localstorage`
-- `initial_language_from_navigator`
-- `localstorage_key`
-
-### Breaking changes
-
-Now `provide_context` accepts a `Option<&'static Language>` instead of `&'static Language` as the initial language of the user.
-
-## 2024-02-08 - v0.0.2
-
-- Added `i18n()` function.
-
-## 2024-02-08 - v0.0.1
-
-First alpha release.
+Alpha releases.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cargo add leptos leptos-fluent fluent-templates unic-langid
 ````rust,ignore
 use fluent_templates::static_loader;
 use leptos::*;
-use leptos_fluent::{leptos_fluent, tr, I18n};
+use leptos_fluent::{leptos_fluent, tr};
 
 static_loader! {
     static LOCALES = {
@@ -61,22 +61,7 @@ pub fn App() -> impl IntoView {
         // Name of the field in local storage to get and set the
         // current language of the user. By default, it is `"lang"`.
         localstorage_key: "language",
-        // Provide context to Leptos discovering the initial language
-        // from the options above. By default, it is `false` and you need
-        // to call `ctx.provide_context(None)` manually to set the
-        // initial language.
-        provide_context: true,
     }};
-
-    // You can pass a `Some(&'static Language)` to the `provide_context`
-    // function of the context to set the initial language manually.
-    let initial_language = move |ctx: &I18n| {
-        // Get the initial language of the user from a server, for example.
-        // ...
-        ctx.default_language()
-    };
-
-    // ctx.provide_context(Some(initial_language(&ctx)));
 
     view! {
         <OtherComponent />

--- a/examples/complete/Cargo.toml
+++ b/examples/complete/Cargo.toml
@@ -20,3 +20,4 @@ web-sys = "0"
 [[bin]]
 name = "main"
 path = "src/main.rs"
+doc = false

--- a/examples/complete/src/lib.rs
+++ b/examples/complete/src/lib.rs
@@ -21,7 +21,6 @@ pub fn App() -> impl IntoView {
         initial_language_from_localstorage: true,
         initial_language_from_navigator: true,
         localstorage_key: "language",
-        provide_context: true,
     }};
 
     view! { <OtherComponent/> }

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -19,3 +19,4 @@ fluent-templates = "0"
 [[bin]]
 name = "main"
 path = "src/main.rs"
+doc = false

--- a/examples/minimal/src/lib.rs
+++ b/examples/minimal/src/lib.rs
@@ -14,7 +14,6 @@ pub fn App() -> impl IntoView {
     leptos_fluent! {{
         locales: LOCALES,
         languages: "./locales/languages.json",
-        provide_context: true,
     }};
 
     view! { <OtherComponent/> }

--- a/leptos-fluent-macros/src/lib.rs
+++ b/leptos-fluent-macros/src/lib.rs
@@ -336,7 +336,6 @@ impl Parse for I18nLoader {
 /// [local storage]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
 /// [`navigator.languages`]: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/languages
 /// [`leptos::create_effect`]: https://docs.rs/leptos/latest/leptos/fn.create_effect.html
-/// [`I18n::provide_context`]: https://docs.rs/leptos-fluent/latest/leptos_fluent/struct.I18n.html#method.provide_context
 #[proc_macro]
 pub fn leptos_fluent(
     input: proc_macro::TokenStream,

--- a/leptos-fluent/Cargo.toml
+++ b/leptos-fluent/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/leptos-fluent"
 repository = "https://github.com/mondeja/leptos-fluent"
 
 [dependencies]
-leptos-fluent-macros = "0.0.11"
+leptos-fluent-macros = {path = "../leptos-fluent-macros"}
 fluent-templates = "0"
 leptos = ">=0.1"
 leptos_router = ">=0.1"

--- a/leptos-fluent/src/lib.rs
+++ b/leptos-fluent/src/lib.rs
@@ -15,17 +15,17 @@
 //! - [**Usage**](https://github.com/mondeja/leptos-fluent#usage)
 //! - [**Examples**](https://github.com/mondeja/leptos-fluent/tree/master/examples)
 
-mod localstorage;
-mod url;
+#[doc(hidden)]
+pub mod localstorage;
+#[doc(hidden)]
+pub mod url;
 
 use core::str::FromStr;
 use fluent_templates::{
     fluent_bundle::FluentValue, loader::Loader, LanguageIdentifier,
     StaticLoader,
 };
-use leptos::{
-    expect_context, provide_context, window, RwSignal, SignalGet, SignalSet,
-};
+use leptos::{expect_context, RwSignal, SignalGet, SignalSet};
 pub use leptos_fluent_macros::leptos_fluent;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
@@ -66,11 +66,6 @@ pub struct I18n {
     /// Available languages for the application
     pub languages: &'static [&'static Language],
     pub locales: &'static Lazy<StaticLoader>,
-    pub initial_language_from_url: bool,
-    pub initial_language_from_url_param: &'static str,
-    pub initial_language_from_url_to_localstorage: bool,
-    pub initial_language_from_localstorage: bool,
-    pub initial_language_from_navigator: bool,
     pub localstorage_key: &'static str,
 }
 
@@ -80,74 +75,12 @@ impl Clone for I18n {
             language: Rc::clone(&self.language),
             languages: self.languages,
             locales: self.locales,
-            initial_language_from_url: self.initial_language_from_url,
-            initial_language_from_url_param: self
-                .initial_language_from_url_param,
-            initial_language_from_url_to_localstorage: self
-                .initial_language_from_url_to_localstorage,
-            initial_language_from_localstorage: self
-                .initial_language_from_localstorage,
-            initial_language_from_navigator: self
-                .initial_language_from_navigator,
             localstorage_key: self.localstorage_key,
         }
     }
 }
 
 impl I18n {
-    /// Provides to Leptos the internationalization context.
-    ///
-    /// It also discovers the initial language if the options provided to
-    /// [`leptos_fluent!`] macro are enabled and `None` is passed as the
-    /// initial language.
-    pub fn provide_context(&self, initial_language: Option<&'static Language>) {
-        if let Some(lang) = initial_language {
-            self.language.set(lang);
-        } else {
-            let mut lang: Option<&'static Language> = None;
-            if self.initial_language_from_url {
-                if let Some(l) = url::get(self.initial_language_from_url_param)
-                {
-                    lang = self.language_from_str(&l);
-                    if let Some(l) = lang {
-                        if self.initial_language_from_url_to_localstorage {
-                            localstorage::set(
-                                self.localstorage_key,
-                                &l.id.to_string(),
-                            );
-                        }
-                    }
-                }
-            }
-
-            if self.initial_language_from_localstorage && lang.is_none() {
-                if let Some(l) = localstorage::get(self.localstorage_key) {
-                    lang = self.language_from_str(&l);
-                }
-            }
-
-            if self.initial_language_from_navigator && lang.is_none() {
-                let languages = window().navigator().languages().to_vec();
-                for raw_language in languages {
-                    let language = raw_language.as_string();
-                    if language.is_none() {
-                        continue;
-                    }
-                    if let Some(l) = self.language_from_str(&language.unwrap())
-                    {
-                        lang = Some(l);
-                        break;
-                    }
-                }
-            }
-
-            if let Some(l) = lang {
-                self.language.set(l);
-            }
-        }
-        provide_context::<I18n>(self.clone());
-    }
-
     /// Translate a text identifier to the current language.
     ///
     /// ```rust,ignore

--- a/leptos-fluent/src/localstorage.rs
+++ b/leptos-fluent/src/localstorage.rs
@@ -1,4 +1,4 @@
-pub(crate) fn get(key: &str) -> Option<String> {
+pub fn get(key: &str) -> Option<String> {
     ::leptos::window()
         .local_storage()
         .unwrap()
@@ -7,7 +7,7 @@ pub(crate) fn get(key: &str) -> Option<String> {
         .unwrap()
 }
 
-pub(crate) fn set(key: &str, value: &str) {
+pub fn set(key: &str, value: &str) {
     ::leptos::window()
         .local_storage()
         .unwrap()


### PR DESCRIPTION
Also removes the parameter `provide_context` of `leptos_fluent!` and the method `I18n::provide_context`: the context is now always provided.