### PR TITLE
Reduce cloning and simplify some iteration

### DIFF
--- a/end2end/Cargo.toml
+++ b/end2end/Cargo.toml
@@ -15,6 +15,6 @@ web-sys = { version = "0.3", features = [
   "Storage",
   "UrlSearchParams"
 ] }
-wasm-bindgen = ">=0.1"
+wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 leptos = "0.6"

--- a/examples/ssr-hydrate-actix/Cargo.toml
+++ b/examples/ssr-hydrate-actix/Cargo.toml
@@ -17,7 +17,7 @@ leptos_actix = { version = "0.6", optional = true }
 leptos_router = "0.6"
 leptos-fluent = { path = "../../leptos-fluent" }
 fluent-templates = "0.9"
-wasm-bindgen = "=0.2.92"
+wasm-bindgen = "=0.2.93"
 
 [features]
 csr = [

--- a/examples/ssr-hydrate-axum/Cargo.toml
+++ b/examples/ssr-hydrate-axum/Cargo.toml
@@ -23,7 +23,7 @@ leptos-fluent = { path = "../../leptos-fluent", features = [
   "yaml"
 ], default-features = false }
 fluent-templates = "0.9"
-wasm-bindgen = "=0.2.92"
+wasm-bindgen = "=0.2.93"
 
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]


### PR DESCRIPTION
Back when I was peeking at the codebase before I made [this old issue](https://github.com/mondeja/leptos-fluent/issues/198), I noticed there was some cloning that didn't need to happen. In this PR, I eliminated some clones where it was easy to do so. I also expressed the parts of the code that iterate over translations in a more idiomatic way.