### PR TITLE
Use single curly braces for `leptos_fluent!` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2024-09-25 - [0.1.23]
+
+### Enhancements
+
+- Allow single braces syntax for `leptos_fluent!` macro. The current
+  syntax `leptos_fluent! {{ ... }}` is still supported but now triggers
+  a deprecation warning. It will not be supported from `v0.2`.
+  Use `leptos_fluent! { ... }` instead.
+
 ## 2024-09-24 - [0.1.22]
 
 ### Bug fixes
@@ -514,6 +523,7 @@ version to `0.1` during installation.
 
 - Added all ISO-639-1 and ISO-639-2 languages.
 
+[0.1.23]: https://github.com/mondeja/leptos-fluent/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/mondeja/leptos-fluent/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/mondeja/leptos-fluent/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/mondeja/leptos-fluent/compare/v0.1.19...v0.1.20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,13 +65,13 @@
   `leptos_fluent!` macro:
 
   ```rust
-  leptos_fluent! {{
+  leptos_fluent! {
       // ...
       #[cfg(debug_assertions)]
       set_language_to_url_param: true,
       #[cfg(not(debug_assertions))]
       set_language_to_url_param: false,
-  }}
+  }
   ```
 
 ## 2024-08-03 - [0.1.10]
@@ -84,11 +84,11 @@
   For example, only use a languages file when compiling on Unix systems:
 
   ```rust
-  leptos_fluent! {{
+  leptos_fluent! {
       // ...
       #[cfg(target_family = "unix")]
       languages: "./locales/languages.json",
-  }}
+  }
   ```
 
 ## 2024-08-02 - [0.1.9]
@@ -159,13 +159,13 @@
 - Accept [configuration conditional checks] directly in most macro parameters:
 
   ```rust
-  leptos_fluent! {{
+  leptos_fluent! {
       // ...
       #[cfg(debug_assertions)]
       initial_language_from_url_param: true,
       #[cfg(debug_assertions)]
       set_language_to_url_param: true,
-  }}
+  }
   ```
 
 [configuration conditional checks]: https://doc.rust-lang.org/rust-by-example/attribute/cfg.html

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,6 +1868,7 @@ dependencies = [
  "leptos",
  "leptos-fluent",
  "pathdiff",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
  "serde",
@@ -2688,6 +2689,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "smallvec",
+]
+
+[[package]]
+name = "proc-macro-warning"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834da187cfe638ae8abb0203f0b33e5ccdb02a28e7199f2f47b3e2754f50edca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ static_loader! {
 fn App() -> impl IntoView {
     // See all options in the reference at
     // https://mondeja.github.io/leptos-fluent/leptos_fluent.html
-    leptos_fluent! {{
+    leptos_fluent! {
         // Path to the locales directory, relative to Cargo.toml.
         locales: "./locales",
         // Static translations struct provided by fluent-templates.
@@ -178,7 +178,7 @@ fn App() -> impl IntoView {
         data_file_key: "my-app",
         // Set the language selected to a data file.
         set_language_to_data_file: true,
-    }};
+    };
 
     view! {
         <TranslatableComponent />

--- a/book/src/basic-usage.md
+++ b/book/src/basic-usage.md
@@ -46,10 +46,10 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "./locales",
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/book/src/checking-translations.md
+++ b/book/src/checking-translations.md
@@ -9,17 +9,17 @@ The pattern must be relative to the location of the _Cargo.toml_ file.
 For single crate projects, it would be something like:
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     check_translations: "./src/**/*.rs",
-}}
+}
 ```
 
 For workspace projects, it could be something like:
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     check_translations: "../{app,components}/src/**/*.rs",
-}}
+}
 ```
 
 ## Translations error messages

--- a/book/src/faqs.md
+++ b/book/src/faqs.md
@@ -72,9 +72,9 @@ pub fn App() -> impl IntoView {
 
 #[component]
 pub fn Child() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         // ...
-    }};
+    };
     view! {
         <div on:click=|_| {
             tr!("my-translation");
@@ -101,9 +101,9 @@ pub fn App() -> impl IntoView {
 
 #[component]
 pub fn Child() -> impl IntoView {
-    let i18n = leptos_fluent! {{
+    let i18n = leptos_fluent! {
         // ...
-    }};
+    };
     view! {
         <div on:click=|_| {
             tr!(i18n, "my-translation");

--- a/book/src/faqs.md
+++ b/book/src/faqs.md
@@ -23,9 +23,9 @@ whichs provides utilities for parsing the Fluent syntax.
 ```rust
 use leptos_fluent::leptos_fluent;
 
-let i18n = leptos_fluent! {{
+let i18n = leptos_fluent! {
     // ...
-}};
+};
 
 leptos::logging::log!("i18n context: {i18n:?}");
 ```
@@ -38,10 +38,10 @@ Use an expression to set the cookie attributes and will not be validated.
 
 ```rust
 let attrs = "SameSite=Strict; MyCustomAttr=MyCustomValue;";
-leptos_fluent! {{
+leptos_fluent! {
     cookie_attrs: attrs,
     // ...
-}}
+};
 ```
 
 [cookie attributes]: https://developer.mozilla.org/docs/Web/API/Document/cookie#write_a_new_cookie
@@ -138,10 +138,10 @@ Use `provide_meta_context` at the macro initialization and get them
 with the method `I18n::meta`:
 
 ```rust
-let i18n = leptos_fluent! {{
+let i18n = leptos_fluent! {
     // ...
     provide_meta_context: true,
-}};
+};
 
 println!("Macro parameters: {:?}", i18n.meta().unwrap());
 ```
@@ -149,13 +149,13 @@ println!("Macro parameters: {:?}", i18n.meta().unwrap());
 ### [Configuration conditional checks]
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     #[cfg(debug_assertions)]
     set_language_to_url_param: true,
     #[cfg(not(debug_assertions))]
     set_language_to_url_param: false,
-}}
+}
 ```
 
 [configuration conditional checks]: https://doc.rust-lang.org/rust-by-example/attribute/cfg.html

--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -52,10 +52,10 @@ in the [`leptos_fluent!`] macro pointing to a languages file. This file must
 be relative to the _Cargo.toml_ file.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     languages: "./locales/languages.json",
     // ...
-}}
+}
 ```
 
 ```json
@@ -95,10 +95,10 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         languages: "./locales/languages.json5",
-    }};
+    };
 }
 ```
 

--- a/book/src/leptos_fluent.md
+++ b/book/src/leptos_fluent.md
@@ -6,10 +6,10 @@ The `leptos_fluent!` macro is used to load the translations and set the current
 locale. It is used in the root component of the application.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     translations: [TRANSLATIONS],
-}}
+};
 ```
 
 <!-- toc -->
@@ -19,7 +19,7 @@ leptos_fluent! {{
 ### <span style="opacity:.5">CSR </span> | Local storage from navigator
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     translations: [TRANSLATIONS],
 
@@ -30,13 +30,13 @@ leptos_fluent! {{
     initial_language_from_url_param: true,
     initial_language_from_url_param_to_localstorage: true,
     localstorage_key: "lang",
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR + SSR </span> | Cookie from navigator and header
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     translations: [TRANSLATIONS],
 
@@ -48,7 +48,7 @@ leptos_fluent! {{
     initial_language_from_url_param_to_cookie: true,
     initial_language_from_accept_language_header: true,
     cookie_name: "lf-lang",
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -58,7 +58,7 @@ leptos_fluent! {{
 <!-- markdownlint-enable MD013 -->
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     translations: [TRANSLATIONS],
 
@@ -67,7 +67,7 @@ leptos_fluent! {{
     initial_language_from_data_file: true,
     set_language_to_data_file: true,
     data_file_key: "system-language-example",
-}}
+}
 ```
 
 ## Processing steps
@@ -94,7 +94,7 @@ Sources are read-only and targets are read-write.
 
 ````admonish example
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ..
     // Get the initial language from the source operative system
     initial_language_from_system: true,
@@ -106,7 +106,7 @@ leptos_fluent! {{
     set_language_to_data_file: true,
     // Unique file name to set the language for this app:
     data_file_key: "system-language-example",
-}};
+};
 ```
 ````
 
@@ -128,11 +128,11 @@ static_loader! {
     };
 }
 
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     translations: [TRANSLATIONS],
     // ^^^^^^^^^^^^^^^^^^^^^^^^^
-}}
+}
 ```
 
 Must be the same identifier used in the [`fluent_templates::static_loader!`]
@@ -145,11 +145,11 @@ files for the translations. Must be relative to the _Cargo.toml_ file, the same
 used in the [`fluent_templates::static_loader!`] macro.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     // ^^^^^^^^^^^^^^^^^
     translations: [TRANSLATIONS],
-}}
+}
 ```
 
 ### `core_locales`
@@ -166,12 +166,12 @@ static_loader! {
     };
 }
 
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     core_locales: "./locales/core",
     // ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     translations: [TRANSLATIONS],
-}}
+}
 ```
 
 ### `languages`
@@ -180,12 +180,12 @@ Path to a file containing the list of languages supported by the application.
 Must be relative to the _Cargo.toml_ file.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     locales: "./locales",
     languages: "./locales/languages.json",
     // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     translations: [TRANSLATIONS],
-}}
+}
 ```
 
 ```admonish tip
@@ -248,23 +248,23 @@ Must be a [glob] relative to the _Cargo.toml_ file.
 - For single crate projects:
 
   ```rust
-  leptos_fluent! {{
+  leptos_fluent! {
       locales: "./locales",
       translations: [TRANSLATIONS],
       check_translations: "./src/**/*.rs",
       // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  }}
+  }
   ```
 
 - For workspace projects:
 
   ```rust
-  leptos_fluent! {{
+  leptos_fluent! {
       locales: "./locales",
       translations: [TRANSLATIONS],
       check_translations: "../{app,components}/src/**/*.rs",
       // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  }}
+  }
   ```
 
 ### <span style="opacity:.5">CSR </span> | `sync_html_tag_lang`
@@ -274,10 +274,10 @@ using [`leptos::create_effect`]. Can be a literal boolean or an expression
 that will be evaluated at runtime.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     sync_html_tag_lang: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `sync_html_tag_dir`
@@ -288,10 +288,10 @@ using [`leptos::create_effect`].
 Can be a literal boolean or an expression that will be evaluated at runtime.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     sync_html_tag_dir: true,
-}}
+}
 ```
 
 For custom languages from a languages file, specify a third element in
@@ -314,10 +314,10 @@ language.
 Name of [URL parameter] used to manage the current language.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     url_param: "lang",
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR + SSR </span> | `initial_language_from_url_param`
@@ -325,10 +325,10 @@ leptos_fluent! {{
 Set initial language from [URL parameter].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_param: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_url_param_to_localstorage`
@@ -336,10 +336,10 @@ leptos_fluent! {{
 Get initial language from [URL parameter] and save it to [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_param_to_localstorage: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_url_param_to_cookie`
@@ -347,10 +347,10 @@ leptos_fluent! {{
 Get initial language from [URL parameter] and save it to a [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_param_to_cookie: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `set_language_to_url_param`
@@ -358,10 +358,10 @@ leptos_fluent! {{
 Synchronize current language with [URL parameter].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_to_url_param: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR + SSR </span> | `url_path`
@@ -378,10 +378,10 @@ fn get_language_from_url_path(path: &str) -> &str {
     ""
 }
 
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     url_path: get_language_from_url_path,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR + SSR </span> | `initial_language_from_url_path`
@@ -389,10 +389,10 @@ leptos_fluent! {{
 Set initial language from [URL path].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_path: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_url_path_to_cookie`
@@ -400,10 +400,10 @@ leptos_fluent! {{
 Set initial language from [URL path] to a [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_path_to_cookie: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_url_path_to_localstorage`
@@ -411,10 +411,10 @@ leptos_fluent! {{
 Set initial language from [URL path] to [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_path_to_localstorage: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -426,10 +426,10 @@ leptos_fluent! {{
 [Local storage] key to manage the current language.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     localstorage_key: "lang",
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_localstorage`
@@ -437,10 +437,10 @@ leptos_fluent! {{
 Get initial language from [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_localstorage: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_localstorage_to_cookie`
@@ -448,10 +448,10 @@ leptos_fluent! {{
 Get initial language from [local storage] and save it to a [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_localstorage_to_cookie: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `set_language_to_localstorage`
@@ -459,10 +459,10 @@ leptos_fluent! {{
 Set the current language to [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_to_localstorage: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_navigator`
@@ -470,10 +470,10 @@ leptos_fluent! {{
 Get the initial language from [`navigator.languages`].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_navigator: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_navigator_to_localstorage`
@@ -481,10 +481,10 @@ leptos_fluent! {{
 Get the initial language from [`navigator.languages`] and save it in the [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_navigator_to_localstorage: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_navigator_to_cookie`
@@ -492,10 +492,10 @@ leptos_fluent! {{
 Get the initial language from [`navigator.languages`] and save it in a [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_navigator_to_cookie: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `set_language_from_navigator`
@@ -504,10 +504,10 @@ When the user changes the language in the browser settings, the language change
 will be reflected in the client.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_from_navigator: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">SSR </span> | `initial_language_from_accept_language_header`
@@ -515,10 +515,10 @@ leptos_fluent! {{
 Get the initial language from the [`Accept-Language`] header.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_accept_language_header: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -531,10 +531,10 @@ Name of the [cookie] that will be used to manage the current language. By defaul
 it is `"lf-lang"`.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     cookie_name: "lang",
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -546,20 +546,20 @@ leptos_fluent! {{
 [Cookie attributes] to set on the language [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     cookie_attrs: "SameSite=Strict; Secure",
-}}
+}
 ```
 
 If value is an expression the [cookie] will not be validated at compile time:
 
 ```rust
 let attrs = "SameSite=Strict; Secure; MyCustomCookie=value"
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     cookie_attrs: attrs,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR + SSR </span> | `initial_language_from_cookie`
@@ -567,10 +567,10 @@ leptos_fluent! {{
 Get the initial language from the cookie.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_cookie: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `initial_language_from_cookie_to_localstorage`
@@ -578,10 +578,10 @@ leptos_fluent! {{
 Get the initial language from the cookie and save it in the [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_cookie_to_localstorage: true,
-}}
+}
 ```
 
 ### <span style="opacity:.5">CSR </span> | `set_language_to_cookie`
@@ -589,10 +589,10 @@ leptos_fluent! {{
 Set the current language to the cookie.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_to_cookie: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -604,10 +604,10 @@ leptos_fluent! {{
 Get the initial language from the system.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_system: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -619,10 +619,10 @@ leptos_fluent! {{
 Get the initial language from a data file.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_data_file: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -634,10 +634,10 @@ leptos_fluent! {{
 Get the initial language from the system and save it in a data file.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_system_to_data_file: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -649,10 +649,10 @@ leptos_fluent! {{
 Set the current language to a data file.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_to_data_file: true,
-}}
+}
 ```
 
 <!-- markdownlint-disable MD013 -->
@@ -665,10 +665,10 @@ Key to manage the current language in the data file. It should be unique
 per application.
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     data_file_key: "my-app",
-}}
+}
 ```
 
 ### `provide_meta_context`
@@ -677,10 +677,10 @@ Provide the macro meta information at runtime as a context.
 Get it using `I18n::meta`:
 
 ```rust
-let i18n = leptos_fluent! {{
+let i18n = leptos_fluent! {
     // ...
     provide_meta_context: true,
-}};
+};
 
 println!("Macro parameters: {:?}", i18n.meta().unwrap());
 ```
@@ -690,10 +690,10 @@ println!("Macro parameters: {:?}", i18n.meta().unwrap());
 Get the initial language from a [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_server_function: initial_language_server_function,
-}}
+}
 
 /// Server function to set the initial language
 #[server(InitialLanguage, "/api")]
@@ -715,10 +715,10 @@ The function must return a `Result<Option<String>, ServerFnError>`.
 Set the current language to a [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     set_language_to_server_function: set_language_server_function,
-}}
+}
 
 /// Server function to update the current language
 #[server(SetLanguage, "/api")]
@@ -742,10 +742,10 @@ Get the initial language from [local storage] and set it to a
 [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_localstorage_to_server_function: set_language_server_function,
-}}
+}
 
 #[server(SetLanguage, "/api")]
 pub async fn set_language_server_function(
@@ -762,10 +762,10 @@ Get the initial language from a [cookie] and set it to a
 [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_cookie_to_server_function: set_language_server_function,
-}}
+}
 
 #[server(SetLanguage, "/api")]
 pub async fn set_language_server_function(
@@ -782,10 +782,10 @@ Get the initial language from [`navigator.languages`] and set it to a
 [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_navigator_to_server_function: set_language_server_function,
-}}
+}
 
 #[server(SetLanguage, "/api")]
 pub async fn set_language_server_function(
@@ -802,10 +802,10 @@ Get the initial language from a [URL parameter] and set it to a
 [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_param_to_server_function: set_language_server_function,
-}}
+}
 
 #[server(SetLanguage, "/api")]
 pub async fn set_language_server_function(
@@ -821,10 +821,10 @@ pub async fn set_language_server_function(
 Get the initial language from a [URL path] and set it to a [server function].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_url_path_to_server_function: set_language_server_function,
-}}
+}
 
 #[server(SetLanguage, "/api")]
 pub async fn set_language_server_function(
@@ -841,10 +841,10 @@ Get the initial language from a [server function] and set it to a
 [cookie].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_server_function_to_cookie: true,
-}}
+}
 ```
 
 ### `initial_language_from_server_function_to_localstorage`
@@ -853,10 +853,10 @@ Get the initial language from a [server function] and set it to
 [local storage].
 
 ```rust
-leptos_fluent! {{
+leptos_fluent! {
     // ...
     initial_language_from_server_function_to_localstorage: true,
-}}
+}
 ```
 
 [`fluent_templates::static_loader!`]: https://docs.rs/fluent-templates/latest/fluent_templates/macro.static_loader.html

--- a/end2end/tests/context_outside_reactive_ownership_tree.rs
+++ b/end2end/tests/context_outside_reactive_ownership_tree.rs
@@ -13,7 +13,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 fn App() -> impl IntoView {
     view! {
         <Show when=|| true>
-            <Child/>
+            <Child />
         </Show>
     }
 }
@@ -21,10 +21,10 @@ fn App() -> impl IntoView {
 #[component]
 fn Child() -> impl IntoView {
     use wasm_bindgen::JsCast;
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
-    }};
+    };
     view! {
         <div
             id="fails"

--- a/end2end/tests/cookie.rs
+++ b/end2end/tests/cookie.rs
@@ -10,13 +10,13 @@ const COOKIE_NAME: &str = "my-weird-cookie-name";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_cookie: true,
         cookie_name: COOKIE_NAME,
         set_language_to_cookie: true,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/cookie_to_localstorage.rs
+++ b/end2end/tests/cookie_to_localstorage.rs
@@ -11,14 +11,14 @@ const LOCALSTORAGE_KEY: &str = "my-weird-localstorage-key";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_cookie: true,
         cookie_name: COOKIE_NAME,
         initial_language_from_cookie_to_localstorage: true,
         localstorage_key: LOCALSTORAGE_KEY,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/localstorage.rs
+++ b/end2end/tests/localstorage.rs
@@ -10,13 +10,13 @@ const LOCALSTORAGE_KEY: &str = "foobarbaz";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_localstorage: true,
         localstorage_key: LOCALSTORAGE_KEY,
         set_language_to_localstorage: true,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/localstorage_to_cookie.rs
+++ b/end2end/tests/localstorage_to_cookie.rs
@@ -11,14 +11,14 @@ const LOCALSTORAGE_KEY: &str = "my-weird-localstorage-key";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_localstorage: true,
         localstorage_key: LOCALSTORAGE_KEY,
         initial_language_from_localstorage_to_cookie: true,
         cookie_name: COOKIE_NAME,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/url_param.rs
+++ b/end2end/tests/url_param.rs
@@ -10,13 +10,13 @@ const URL_PARAM: &str = "my-weird-url-param";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_url_param: true,
         url_param: URL_PARAM,
         set_language_to_url_param: true,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/url_param_to_cookie.rs
+++ b/end2end/tests/url_param_to_cookie.rs
@@ -11,14 +11,14 @@ const COOKIE_NAME: &str = "my-weird-cookie-name";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_url_param: true,
         url_param: URL_PARAM,
         initial_language_from_url_param_to_cookie: true,
         cookie_name: COOKIE_NAME,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/end2end/tests/url_param_to_localstorage.rs
+++ b/end2end/tests/url_param_to_localstorage.rs
@@ -11,14 +11,14 @@ const LOCALSTORAGE_KEY: &str = "my-weird-localstorage-key";
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../examples/csr-minimal/locales",
         initial_language_from_url_param: true,
         url_param: URL_PARAM,
         initial_language_from_url_param_to_localstorage: true,
         localstorage_key: LOCALSTORAGE_KEY,
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/examples/csr-complete/src/lib.rs
+++ b/examples/csr-complete/src/lib.rs
@@ -11,7 +11,7 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         languages: "./locales/languages.json",
         locales: "./locales",
@@ -36,7 +36,7 @@ pub fn App() -> impl IntoView {
         initial_language_from_navigator_to_cookie: true,
         initial_language_from_navigator_to_localstorage: true,
         set_language_from_navigator: true,
-    }};
+    };
 
     view! { <ChildComponent/> }
 }

--- a/examples/csr-minimal/src/lib.rs
+++ b/examples/csr-minimal/src/lib.rs
@@ -11,10 +11,10 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "./locales",
-    }};
+    };
 
     view! { <LanguageSelector/> }
 }

--- a/examples/ssr-hydrate-actix/src/app.rs
+++ b/examples/ssr-hydrate-actix/src/app.rs
@@ -14,7 +14,7 @@ static_loader! {
 #[component]
 pub fn App() -> impl IntoView {
     provide_meta_context();
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "./locales",
         #[cfg(debug_assertions)] check_translations: "./src/**/*.rs",
@@ -49,7 +49,7 @@ pub fn App() -> impl IntoView {
         initial_language_from_url_path_to_cookie: true,
         initial_language_from_url_path_to_localstorage: true,
         initial_language_from_url_path_to_server_function: set_language_server_function,
-    }};
+    };
 
     view! {
         <Title text=move || tr!("welcome-to-leptos")/>

--- a/examples/ssr-hydrate-axum/src/app.rs
+++ b/examples/ssr-hydrate-axum/src/app.rs
@@ -18,7 +18,7 @@ pub static COMPOUND: &[&Lazy<StaticLoader>] = &[&TRANSLATIONS, &TRANSLATIONS];
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS, TRANSLATIONS] + COMPOUND,
         locales: "./locales",
         check_translations: "./src/**/*.rs",
@@ -41,7 +41,7 @@ pub fn App() -> impl IntoView {
         initial_language_from_navigator: true,
         initial_language_from_navigator_to_localstorage: true,
         initial_language_from_accept_language_header: true,
-    }};
+    };
 
     view! {
         <Title text=move || tr!("welcome-to-leptos")/>

--- a/examples/system-gtk/src/main.rs
+++ b/examples/system-gtk/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
     // Connect to "activate" signal of `app`
     app.connect_activate(build_ui);
 
-    let i18n = leptos_fluent! {{
+    let i18n = leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "./locales",
         check_translations: "./src/**/*.rs",
@@ -53,7 +53,7 @@ fn main() {
         set_language_to_data_file: true,
         data_file_key: "leptos-fluent-gtk-example",
         provide_meta_context: true,
-    }};
+    };
 
     tracing::info!("Macro parameters: {:?}", i18n.meta().unwrap());
 

--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = { version = "1", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 json5 = { version = "0.4", optional = true }
 tracing = { version = "0.1", optional = true }
+proc-macro-warning = "1"
 
 [dev-dependencies]
 trybuild = "1"

--- a/leptos-fluent-macros/src/lib.rs
+++ b/leptos-fluent-macros/src/lib.rs
@@ -58,7 +58,7 @@ pub(crate) fn debug(msg: &str) {
 ///
 /// #[component]
 /// pub fn App() -> impl IntoView {
-///     leptos_fluent! {{
+///     leptos_fluent! {
 ///         translations: [TRANSLATIONS],
 ///         languages: "./locales/languages.json",
 ///         sync_html_tag_lang: true,
@@ -78,7 +78,7 @@ pub(crate) fn debug(msg: &str) {
 ///         cookie_attrs: "SameSite=Strict; Secure; path=/; max-age=2592000",
 ///         initial_language_from_cookie: true,
 ///         set_language_to_cookie: true,
-///     }};
+///     };
 ///
 ///     view! {
 ///         ...

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/check_translations_cfg_feature.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/check_translations_cfg_feature.rs
@@ -12,12 +12,12 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         #[cfg(feature = "ssr")]
         check_translations: "../../../../leptos-fluent-macros/tests/ui/leptos_fluent/fail/check_translations_cfg_feature.rs"
-    }};
+    };
 
     view! { <p>{move_tr!("select-a-language")}</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/check_translations_cfg_feature.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/check_translations_cfg_feature.stderr
@@ -6,10 +6,10 @@ error: The parameter 'check_translations' of leptos_fluent! macro does not accep
            let check_translations_dyn = { ... };
        }
 
-       leptos_fluent! {{
+       leptos_fluent! {
            // ...
            check_translations: check_translations_dyn,
-       }};
+       };
        ```
   --> tests/ui/leptos_fluent/fail/check_translations_cfg_feature.rs:18:9
    |

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.rs
@@ -3,9 +3,7 @@ use leptos_fluent_macros::leptos_fluent;
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
-
-    }};
+    leptos_fluent! {};
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
@@ -1,5 +1,5 @@
 error: Missing `translations` parameter
-Error:  --> tests/ui/leptos_fluent/fail/empty.rs:6:5
+ --> tests/ui/leptos_fluent/fail/empty.rs:6:5
   |
 6 |     leptos_fluent! {};
   |     ^^^^^^^^^^^^^^^^^

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
@@ -1,9 +1,9 @@
 error: Missing `translations` parameter
  --> tests/ui/leptos_fluent/fail/empty.rs:6:5
   |
-6 | /     leptos_fluent! {{
+6 | /     leptos_fluent! {
 7 | |
-8 | |     }};
+8 | |     };
   | |______^
   |
   = note: this error originates in the macro `leptos_fluent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty.stderr
@@ -1,9 +1,7 @@
 error: Missing `translations` parameter
- --> tests/ui/leptos_fluent/fail/empty.rs:6:5
+Error:  --> tests/ui/leptos_fluent/fail/empty.rs:6:5
   |
-6 | /     leptos_fluent! {
-7 | |
-8 | |     };
-  | |______^
+6 |     leptos_fluent! {};
+  |     ^^^^^^^^^^^^^^^^^
   |
   = note: this error originates in the macro `leptos_fluent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty_parameter.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty_parameter.rs
@@ -11,11 +11,11 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         : "foo",
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty_value.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/empty_value.rs
@@ -11,11 +11,11 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         url_param: ,
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/invalid_parameter.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/invalid_parameter.rs
@@ -11,11 +11,11 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         invalid_parameter: "foo",
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.rs
@@ -11,9 +11,9 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.stderr
@@ -1,9 +1,9 @@
 error: Missing `locales` parameter
   --> tests/ui/leptos_fluent/fail/locales_required.rs:14:5
    |
-14 | /     leptos_fluent! {{
+14 | /     leptos_fluent! {
 15 | |         translations: [TRANSLATIONS],
-16 | |     }};
+16 | |     };
    | |______^
    |
    = note: this error originates in the macro `leptos_fluent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.stderr
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/fail/locales_required.stderr
@@ -4,6 +4,6 @@ error: Missing `locales` parameter
 14 | /     leptos_fluent! {
 15 | |         translations: [TRANSLATIONS],
 16 | |     };
-   | |______^
+   | |_____^
    |
    = note: this error originates in the macro `leptos_fluent` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/check_translations_cfg_not_debug.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/check_translations_cfg_not_debug.rs
@@ -18,12 +18,12 @@ pub fn App() -> impl IntoView {
 #[cfg(debug_assertions)]
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         #[cfg(not(debug_assertions))]
         check_translations: "../../../../leptos-fluent-macros/tests/ui/leptos_fluent/pass/check_translations_cfg.rs"
-    }};
+    };
 
     view! { <p>{move_tr!("select-a-language")}</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/compile_time_exprpath_target_predicate.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/compile_time_exprpath_target_predicate.rs
@@ -11,12 +11,12 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
         languages: "../../../../examples/csr-complete/locales/languages.json",
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/complete.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/complete.rs
@@ -11,7 +11,7 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         sync_html_tag_lang: true,
@@ -31,7 +31,7 @@ pub fn App() -> impl IntoView {
         initial_language_from_localstorage_to_cookie: true,
         set_language_to_localstorage: true,
         initial_language_from_navigator: true,
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/minimal.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/minimal.rs
@@ -11,10 +11,10 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/multiple_cfg_conditional_cheks.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/multiple_cfg_conditional_cheks.rs
@@ -11,7 +11,7 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         // A comment
@@ -24,7 +24,7 @@ pub fn App() -> impl IntoView {
         sync_html_tag_dir: true,
         #[cfg(not(debug_assertions))]
         sync_html_tag_dir: false,
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/set_to_url_param_cfg_feature.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/set_to_url_param_cfg_feature.rs
@@ -12,12 +12,12 @@ static_loader! {
 
 #[component]
 pub fn App() -> impl IntoView {
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         locales: "../../../../examples/csr-minimal/locales",
         #[cfg(feature = "ssr")]
         set_language_to_url_param: true
-    }};
+    };
 
     view! { <p>{move_tr!("select-a-language")}</p> }
 }

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/pass/struct_field_init_shorthand.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/pass/struct_field_init_shorthand.rs
@@ -14,12 +14,12 @@ pub fn App() -> impl IntoView {
     let cookie_name = "my_cookie";
     let initial_language_from_cookie = true;
 
-    leptos_fluent! {{
+    leptos_fluent! {
         translations: [TRANSLATIONS],
         cookie_name,
         locales: "../../../../examples/csr-minimal/locales",
         initial_language_from_cookie,
-    }};
+    };
 
     view! { <p>Foo</p> }
 }

--- a/leptos-fluent/README.md
+++ b/leptos-fluent/README.md
@@ -89,7 +89,7 @@ static_loader! {
 fn App() -> impl IntoView {
     // See all options in the reference at
     // https://mondeja.github.io/leptos-fluent/leptos_fluent.html
-    leptos_fluent! {{
+    leptos_fluent! {
         // Path to the locales directory, relative to Cargo.toml.
         locales: "./locales",
         // Static translations struct provided by fluent-templates.
@@ -178,7 +178,7 @@ fn App() -> impl IntoView {
         data_file_key: "my-app",
         // Set the language selected to a data file.
         set_language_to_data_file: true,
-    }};
+    };
 
     view! {
         <TranslatableComponent />

--- a/leptos-fluent/src/lib.rs
+++ b/leptos-fluent/src/lib.rs
@@ -87,7 +87,7 @@
 //! fn App() -> impl IntoView {
 //!     // See all options in the reference at
 //!     // https://mondeja.github.io/leptos-fluent/leptos_fluent.html
-//!     leptos_fluent! {{
+//!     leptos_fluent! {
 //!         // Path to the locales directory, relative to Cargo.toml.
 //!         locales: "./locales",
 //!         // Static translations struct provided by fluent-templates.
@@ -176,7 +176,7 @@
 //!         data_file_key: "my-app",
 //!         // Set the language selected to a data file.
 //!         set_language_to_data_file: true,
-//!     }};
+//!     };
 //!
 //!     view! {
 //!         <TranslatableComponent />
@@ -443,10 +443,10 @@ impl I18n {
     /// raise an error message.
     ///
     /// ```rust,ignore
-    /// let i18n = leptos_fluent! {{
+    /// let i18n = leptos_fluent! {
     ///     // ...
     ///     provide_meta_context: true,
-    /// }};
+    /// };
     ///
     /// leptos::logging::log!("Macro parameters: {:?}", i18n.meta().unwrap());
     /// ```


### PR DESCRIPTION
Resolves #223

The double curly braces syntax support is kept but will be removed at v0.2. Now triggers a deprecation warning.