### PR TITLE
Fully qualify `window()` in `leptos_fluent!`

### DIFF
--- a/leptos-fluent-macros/src/lib.rs
+++ b/leptos-fluent-macros/src/lib.rs
@@ -1467,7 +1467,7 @@ pub fn leptos_fluent(
             }).collect();
 
         let window_navigator_languages_quote = quote! {
-            let languages = window().navigator().languages().to_vec();
+            let languages = ::leptos::leptos_dom::window().navigator().languages().to_vec();
             for raw_language in languages {
                 let language = raw_language.as_string();
                 if language.is_none() {


### PR DESCRIPTION
This change avoids an error of this nature when invoking the macro:
```
error[E0425]: cannot find function `window` in this scope
   --> src\fluent.rs:29:5
    |
29  | /     leptos_fluent! {
30  | |         // Path to the locales directory, relative to Cargo.toml.
31  | |         locales: "./locales",
32  | |         // Static translations struct provided by fluent-templates.
...   |
117 | |         // set_language_to_data_file: true,
118 | |     };
    | |_____^ not found in this scope
    |
    = note: this error originates in the macro `leptos_fluent` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these functions
    |
1   + use leptos::window;
    |
1   + use web_sys::window;
    |
```