### PR TITLE
chore: Fix leptos dependency range

### DIFF
--- a/leptos-fluent/Cargo.toml
+++ b/leptos-fluent/Cargo.toml
@@ -17,8 +17,8 @@ fluent-templates = { version = ">=0.13", default-features = false, features = [
   "macros",
   "walkdir",
 ] }
-leptos = "0.7,<0.9"
-leptos_meta = "0.7,<0.9"
+leptos = ">=0.7,<0.9"
+leptos_meta = ">=0.7,<0.9"
 web-sys = { version = ">=0.1", features = [
   "HtmlDocument",
   "Navigator",


### PR DESCRIPTION
The current version range does not match leptos 0.8 as expected. See the following rust playground: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=a88350daa7b3bd1968207551acd627b5

Unfortunately, `semver` does not support pre-release versions (https://github.com/dtolnay/semver/issues/323), so the updated range in this PR still won't work for leptos 0.8.0-alpha.