### PR TITLE
fix: Axum cookie extraction logic

### DIFF
--- a/leptos-fluent-macros/src/lib.rs
+++ b/leptos-fluent-macros/src/lib.rs
@@ -1736,8 +1736,8 @@ pub fn leptos_fluent(
                     .get(::axum::http::header::COOKIE)
                     .and_then(|header| header.to_str().ok())
                     .and_then(|cookie| {
-                        let cookie = cookie.split(';').find(|c| c.starts_with(#cookie_name_quote));
-                        cookie.map(|c| c.split('=').nth(1).unwrap().to_string())
+                        let cookie = cookie.split(';').find(|c| c.trim_start().starts_with(#cookie_name_quote));
+                        cookie.map(|c| c.split('=').nth(1).unwrap().trim_start().to_string())
                     });
 
                 if let Some(cookie) = maybe_cookie {


### PR DESCRIPTION
If the "lang" cookie isn't the first one in the set, `.split(';')` would return a value like " lang=en-GB", which wouldn't match the expected `start_with`. Now trims the leading space to avoid this.