### PR TITLE
chore: Allow leptos 0.8.0 pre-release versions

### DIFF
--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -41,7 +41,7 @@ tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 trybuild = "1"
-leptos = "0.7"
+leptos = ">=0.7,0.8.0-alpha,<0.9"
 leptos-fluent = { path = "../leptos-fluent" }
 
 [features]

--- a/leptos-fluent/Cargo.toml
+++ b/leptos-fluent/Cargo.toml
@@ -17,7 +17,7 @@ fluent-templates = { version = ">=0.13", default-features = false, features = [
   "macros",
   "walkdir",
 ] }
-leptos = ">=0.7,<0.9"
+leptos = ">=0.7,0.8.0-alpha,<0.9"
 leptos_meta = ">=0.7,<0.9"
 web-sys = { version = ">=0.1", features = [
   "HtmlDocument",

--- a/leptos-fluent/Cargo.toml
+++ b/leptos-fluent/Cargo.toml
@@ -18,7 +18,7 @@ fluent-templates = { version = ">=0.13", default-features = false, features = [
   "walkdir",
 ] }
 leptos = ">=0.7,0.8.0-alpha,<0.9"
-leptos_meta = ">=0.7,<0.9"
+leptos_meta = ">=0.7,0.8.0-alpha,<0.9"
 web-sys = { version = ">=0.1", features = [
   "HtmlDocument",
   "Navigator",


### PR DESCRIPTION
This is a followup from https://github.com/mondeja/leptos-fluent/pull/312 to enable using leptos 0.8.0 pre-release versions, e.g., leptos-0.8.0-rc1. The `semver` crate still doesn't support pre-release versions in version range declarations, but it does seem to support them in `^` (compatible) version declarations. If we add `0.8.0-alpha` as a supported version, this will also match all other 0.8.0 pre-release versions (and 0.8.* stable versions) per rust's "compatible" semver checks. See the following rust playground for an example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=8fd69c45c6c6e57c288aabbe39bdecfe