### PR TITLE
Bump fluent syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,16 +910,16 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+checksum = "01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
  "intl-memoizer",
  "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
+ "rustc-hash 2.1.1",
+ "self_cell",
  "smallvec",
  "unic-langid",
 ]
@@ -935,18 +935,19 @@ dependencies = [
 
 [[package]]
 name = "fluent-syntax"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
- "thiserror 1.0.69",
+ "memchr",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "fluent-template-macros"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed02449601d0dacdc05cb5e13db5dab8f2b98d773aff5c53b62fad43a1b19a1"
+checksum = "e6222b8a208b9f0e7b984da3616651b0cc74e4461571b118cb1c713e0f7617ee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -957,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-templates"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69855a5fe87629495efca79aec72adfa97954f1006f928e3a2ec750cb3e85386"
+checksum = "f8a893d77c0e48dc3f78421e9cba5d82e02bcb85d4520c506cec2fbebd0f513b"
 dependencies = [
  "fluent-bundle",
  "fluent-langneg",
@@ -2793,15 +2794,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.2.0",
-]
 
 [[package]]
 name = "self_cell"

--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -25,7 +25,7 @@ fluent-templates = { version = ">=0.13.1", default-features = false, features = 
   "macros",
   "walkdir",
 ] }
-fluent-syntax = "0.12"
+fluent-syntax = ">=0.11"
 pathdiff = "0.2"
 # TODO: using the same version for cfg-expr of system-deps until a new system-deps is released
 # The problem related with trybuild locking https://github.com/dtolnay/trybuild/issues/261

--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -25,7 +25,7 @@ fluent-templates = { version = ">=0.13.1", default-features = false, features = 
   "macros",
   "walkdir",
 ] }
-fluent-syntax = ">=0.11"
+fluent-syntax = ">=0.12"
 pathdiff = "0.2"
 # TODO: using the same version for cfg-expr of system-deps until a new system-deps is released
 # The problem related with trybuild locking https://github.com/dtolnay/trybuild/issues/261

--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -21,7 +21,7 @@ quote = "1"
 syn = { version = "2", features = ["visit", "full"] }
 walkdir = ">=2"
 globwalk = "0.9"
-fluent-templates = { version = ">=0.13", default-features = false, features = [
+fluent-templates = { version = ">=0.13.1", default-features = false, features = [
   "macros",
   "walkdir",
 ] }

--- a/leptos-fluent-macros/Cargo.toml
+++ b/leptos-fluent-macros/Cargo.toml
@@ -25,7 +25,7 @@ fluent-templates = { version = ">=0.13", default-features = false, features = [
   "macros",
   "walkdir",
 ] }
-fluent-syntax = "0.11"
+fluent-syntax = "0.12"
 pathdiff = "0.2"
 # TODO: using the same version for cfg-expr of system-deps until a new system-deps is released
 # The problem related with trybuild locking https://github.com/dtolnay/trybuild/issues/261

--- a/leptos-fluent/Cargo.toml
+++ b/leptos-fluent/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 
 [dependencies]
 leptos-fluent-macros = { path = "../leptos-fluent-macros" }
-fluent-templates = { version = ">=0.13", default-features = false, features = [
+fluent-templates = { version = ">=0.13.1", default-features = false, features = [
   "macros",
   "walkdir",
 ] }


### PR DESCRIPTION
I was having a problem with different crates importing different versions of fluent-syntax. This PR bumps the versions of fluent dependencies.