### PR TITLE
feat: Allow providing `customise` closure in `leptos_fluent!`

### DIFF
--- a/examples/ssr-hydrate-actix/src/app.rs
+++ b/examples/ssr-hydrate-actix/src/app.rs
@@ -44,6 +44,7 @@ fn I18nProvider(children: Children) -> impl IntoView {
         initial_language_from_url_path_to_cookie: true,
         initial_language_from_url_path_to_local_storage: true,
         initial_language_from_url_path_to_server_function: set_language_server_function,
+        customise: |bundle| bundle.set_transform(Some(|s| std::borrow::Cow::from(s)))
     }
 }
 

--- a/leptos-fluent-macros/src/lib.rs
+++ b/leptos-fluent-macros/src/lib.rs
@@ -119,6 +119,7 @@ pub fn leptos_fluent(
         default_language,
         check_translations,
         fill_translations,
+        customise,
         provide_meta_context,
         sync_html_tag_lang,
         sync_html_tag_dir,
@@ -2180,11 +2181,18 @@ pub fn leptos_fluent(
             };
 
             #[cfg(feature = "disable-unicode-isolating-marks")]
-            let customise_quote = quote! {
-                customise: |bundle| bundle.set_use_isolating(false),
-            };
+            let customise_quote = customise.map_or(
+                quote! { customise: |bundle| bundle.set_use_isolating(false) },
+                |c| quote! {
+                    customise: |bundle| {
+                        bundle.set_use_isolating(false);
+                        let customise: fn(&mut ::leptos_fluent::__reexports::fluent_templates::FluentBundle<&::leptos_fluent::__reexports::fluent_bundle::FluentResource>) = #c;
+                        customise(bundle);
+                    }
+                }
+            );
             #[cfg(not(feature = "disable-unicode-isolating-marks"))]
-            let customise_quote = quote!();
+            let customise_quote = customise.map_or(quote!(), |c| quote!{ customise: #c });
 
             (
                 quote! {

--- a/leptos-fluent-macros/src/loader.rs
+++ b/leptos-fluent-macros/src/loader.rs
@@ -460,6 +460,7 @@ pub(crate) struct I18nLoader {
     pub core_locales_path: Option<String>,
     pub check_translations: Option<LitBoolOrStr>,
     pub fill_translations: Option<String>,
+    pub customise: Option<syn::ExprClosure>,
     pub provide_meta_context: Vec<LitBool>,
     pub sync_html_tag_lang: Vec<LitBoolExprOrIdent>,
     pub sync_html_tag_dir: Vec<LitBoolExprOrIdent>,
@@ -551,6 +552,7 @@ impl Parse for I18nLoader {
         let mut translations: Option<Translations> = None;
         let mut check_translations: Option<LitBoolOrStr> = None;
         let mut fill_translations: Option<syn::LitStr> = None;
+        let mut customise: Option<syn::ExprClosure> = None;
         let mut provide_meta_context: Vec<LitBool> = Vec::new();
         let mut sync_html_tag_lang: Vec<LitBoolExprOrIdent> = Vec::new();
         let mut sync_html_tag_dir: Vec<LitBoolExprOrIdent> = Vec::new();
@@ -847,6 +849,8 @@ impl Parse for I18nLoader {
                     k,
                     fill_translations
                 );
+            } else if k == "customise" {
+                customise = Some(input.parse()?);
             } else if k == "sync_html_tag_lang" {
                 let mut param = LitBoolExprOrIdent::new();
                 parse_runtime_exprpath!(exprpath, param);
@@ -2062,6 +2066,7 @@ impl Parse for I18nLoader {
             default_language: default_language_and_index,
             check_translations,
             fill_translations: fill_translations.map(|x| x.value()),
+            customise,
             provide_meta_context,
             sync_html_tag_lang,
             sync_html_tag_dir,

--- a/leptos-fluent-macros/tests/ui/leptos_fluent/stable/pass/complete.rs
+++ b/leptos-fluent-macros/tests/ui/leptos_fluent/stable/pass/complete.rs
@@ -32,6 +32,7 @@ fn I18n(children: Children) -> impl IntoView {
         initial_language_from_local_storage_to_cookie: true,
         set_language_to_local_storage: true,
         initial_language_from_navigator: true,
+        customise: |bundle| bundle.set_transform(Some(|s| Cow::from(s)))
     }
 }
 

--- a/leptos-fluent/src/lib.rs
+++ b/leptos-fluent/src/lib.rs
@@ -278,6 +278,8 @@ pub mod __reexports {
     #[doc(hidden)]
     pub use fluent_templates;
     #[doc(hidden)]
+    pub use fluent_bundle;
+    #[doc(hidden)]
     pub use leptos_meta;
     #[doc(hidden)]
     pub use wasm_bindgen;

--- a/leptos-fluent/src/lib.rs
+++ b/leptos-fluent/src/lib.rs
@@ -89,6 +89,8 @@
 //!         // Check translations correctness in the specified files.
 //!         #[cfg(debug_assertions)]
 //!         check_translations: "./src/**/*.rs",
+//!         // Provide a closure to customise fluent bundles.
+//!         customise: |bundle| bundle.set_transform(Some(|s| std::borrow::Cow::from(s))),
 //!
 //!         // Client side options
 //!         // -------------------
@@ -276,9 +278,9 @@ pub mod __reexports {
     #[cfg(feature = "system")]
     pub use current_locale;
     #[doc(hidden)]
-    pub use fluent_templates;
-    #[doc(hidden)]
     pub use fluent_bundle;
+    #[doc(hidden)]
+    pub use fluent_templates;
     #[doc(hidden)]
     pub use leptos_meta;
     #[doc(hidden)]


### PR DESCRIPTION
Currently, the only way to provide a `customise` closure for a fluent bundle is by directly using `fluent_templates::static_loader!` and providing the resulting translation bundle to `leptos_fluent!` in the `translations` field. However, the `translations` field is optional now and may be removed in the future depending on how https://github.com/mondeja/leptos-fluent/issues/361 is implemented.

This PR adds support for providing the `customise` closure to `leptos_fluent!` instead of needing to provide it via `fluent_templates::static_loader!`.

Closes https://github.com/mondeja/leptos-fluent/issues/364